### PR TITLE
Create Database and Tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+*.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# rizz_orm
+# RIZZ ORM
+
 An Object Relational Mapper

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+
+from orm import Table, Column, ForeignKey
+
+
+@pytest.fixture
+def Author():
+    class Author(Table):
+        name = Column(str)
+        age = Column(int)
+
+    return Author
+
+
+@pytest.fixture
+def Book(Author):
+    class Book(Table):
+        title = Column(str)
+        published = Column(int)
+        author = ForeignKey(Author)
+
+    return Book

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
+import os
 import pytest
-
-from orm import Table, Column, ForeignKey
+from orm import Database, Table, Column, ForeignKey
 
 
 @pytest.fixture
@@ -20,3 +20,12 @@ def Book(Author):
         author = ForeignKey(Author)
 
     return Book
+
+
+@pytest.fixture
+def db():
+    DB_PATH = "./test.db"
+    if os.path.exists(DB_PATH):
+        os.remove("./test.db")
+    db = Database(DB_PATH)
+    return db

--- a/orm.py
+++ b/orm.py
@@ -18,7 +18,6 @@ class Database:
         return {x[0] for x in self.connection.execute(SELECT_TABLES_SQL).fetchall()}
 
 
-
 class Table:
     @classmethod
     def _get_create_sql(cls):

--- a/orm.py
+++ b/orm.py
@@ -1,4 +1,8 @@
+import inspect
 import sqlite3
+
+
+# TODO: Use jinja2 templates for constructing SQL
 
 
 class Database:
@@ -9,9 +13,27 @@ class Database:
     def tables(self):
         return []
 
+    def create(self, table):
+        self.connection.execute(table._get_create_sql())
+
 
 class Table:
-    ...
+    @classmethod
+    def _get_create_sql(cls):
+        CREATE_TABLE_SQL = "CREATE TABLE IF NOT EXISTS {name} ({fields});"
+        fields = [
+            "id INTEGER PRIMARY KEY AUTOINCREMENT",
+        ]
+
+        for column_name, field in inspect.getmembers(cls):
+            if isinstance(field, Column):
+                fields.append(f"{column_name} {field.sql_type}")
+            elif isinstance(field, ForeignKey):
+                fields.append(f"{column_name}_id INTEGER")
+
+        fields = ", ".join(fields)
+        table_name = cls.__name__.lower()
+        return CREATE_TABLE_SQL.format(name=table_name, fields=fields)
 
 
 class Column:

--- a/orm.py
+++ b/orm.py
@@ -8,3 +8,29 @@ class Database:
     @property
     def tables(self):
         return []
+
+
+class Table:
+    ...
+
+
+class Column:
+
+    def __init__(self, column_type) -> None:
+        self._type = column_type
+
+    @property
+    def sql_type(self):
+        TYPE_MAP = {
+            int: "INTEGER",
+            float: "REAL",
+            str: "TEXT",
+            bytes: "BLOB",
+            bool: "INTEGER",  # 0 or 1
+        }
+        return TYPE_MAP[self._type]
+
+
+class ForeignKey:
+    def __init__(self, table) -> None:
+        self.table = table

--- a/orm.py
+++ b/orm.py
@@ -1,0 +1,10 @@
+import sqlite3
+
+
+class Database:
+    def __init__(self, path: str):
+        self.connection = sqlite3.Connection(path)
+
+    @property
+    def tables(self):
+        return []

--- a/orm.py
+++ b/orm.py
@@ -9,12 +9,14 @@ class Database:
     def __init__(self, path: str):
         self.connection = sqlite3.Connection(path)
 
-    @property
-    def tables(self):
-        return []
-
     def create(self, table):
         self.connection.execute(table._get_create_sql())
+
+    @property
+    def tables(self):
+        SELECT_TABLES_SQL = "SELECT name FROM sqlite_master WHERE type = 'table';"
+        return {x[0] for x in self.connection.execute(SELECT_TABLES_SQL).fetchall()}
+
 
 
 class Table:

--- a/test_orm.py
+++ b/test_orm.py
@@ -1,0 +1,19 @@
+import sqlite3
+import pytest
+
+from orm import Database
+
+
+def test_create_db():
+    db = Database("./test.db")
+
+    assert isinstance(db.connection, sqlite3.Connection)
+    assert db.tables == []
+
+
+def test_define_tables(Author, Book):
+    assert Author.name.type == str
+    assert Book.author.table == Author
+
+    assert Author.name.sql_type == "TEXT"
+    assert Author.age.sql_type == "INTEGER"

--- a/test_orm.py
+++ b/test_orm.py
@@ -17,3 +17,30 @@ def test_define_tables(Author, Book):
 
     assert Author.name.sql_type == "TEXT"
     assert Author.age.sql_type == "INTEGER"
+
+
+def test_create_tables(Author, Book):
+    db = Database("./test.db")
+
+    db.create(Author)
+    db.create(Book)
+
+    assert Author._get_create_sql() == """
+    CREATE TABLE IF NOT EXISTS author (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        age INTEGER,
+        name TEXT
+    );
+    """
+
+    assert Book._get_create_sql() == """
+    CREATE TABLE IF NOT EXISTS book (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        author_id INTEGER,
+        published INTEGER,
+        title TEXT
+    );
+    """
+
+    for table in ("author", "book"):
+        assert table in db.tables

--- a/test_orm.py
+++ b/test_orm.py
@@ -1,12 +1,8 @@
-import sqlite3
 import pytest
+import sqlite3
 
-from orm import Database
 
-
-def test_create_db():
-    db = Database("./test.db")
-
+def test_create_db(db):
     assert isinstance(db.connection, sqlite3.Connection)
     assert db.tables == []
 
@@ -19,9 +15,7 @@ def test_define_tables(Author, Book):
     assert Author.age.sql_type == "INTEGER"
 
 
-def test_create_tables(Author, Book):
-    db = Database("./test.db")
-
+def test_create_tables(db, Author, Book):
     db.create(Author)
     db.create(Book)
 

--- a/test_orm.py
+++ b/test_orm.py
@@ -12,7 +12,7 @@ def test_create_db():
 
 
 def test_define_tables(Author, Book):
-    assert Author.name.type == str
+    assert Author.name._type == str
     assert Book.author.table == Author
 
     assert Author.name.sql_type == "TEXT"

--- a/test_orm.py
+++ b/test_orm.py
@@ -4,7 +4,7 @@ import sqlite3
 
 def test_create_db(db):
     assert isinstance(db.connection, sqlite3.Connection)
-    assert db.tables == []
+    assert len(db.tables) == 0
 
 
 def test_define_tables(Author, Book):

--- a/test_orm.py
+++ b/test_orm.py
@@ -25,22 +25,11 @@ def test_create_tables(Author, Book):
     db.create(Author)
     db.create(Book)
 
-    assert Author._get_create_sql() == """
-    CREATE TABLE IF NOT EXISTS author (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        age INTEGER,
-        name TEXT
-    );
-    """
+    author_sql = Author._get_create_sql()
+    assert author_sql == "CREATE TABLE IF NOT EXISTS author (id INTEGER PRIMARY KEY AUTOINCREMENT, age INTEGER, name TEXT);"
 
-    assert Book._get_create_sql() == """
-    CREATE TABLE IF NOT EXISTS book (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        author_id INTEGER,
-        published INTEGER,
-        title TEXT
-    );
-    """
+    book_sql = Book._get_create_sql()
+    assert book_sql == "CREATE TABLE IF NOT EXISTS book (id INTEGER PRIMARY KEY AUTOINCREMENT, author_id INTEGER, published INTEGER, title TEXT);"
 
     for table in ("author", "book"):
         assert table in db.tables


### PR DESCRIPTION
Given a Database name, initialize a connection object.

- [x] Add support for SQL column types
- [x] Add support for creating db
- [x] Add support for creating tables

Create db and tables like so:

```python
from rizz_orm.orm import Database, Table


class Employee(Table):
    name = Column(str)
    age = Column(int)

db = Database("./new_db")
db.create(Employee)

assert len(db.tables) == 1
```