### PR TITLE
Add Table.asdict method

### DIFF
--- a/orm.py
+++ b/orm.py
@@ -145,6 +145,11 @@ class Table:
 
         return sql, fields
 
+    @property
+    def asdict(self) -> dict:
+        _, fields, _ = self._get_select_where_sql(self.id)
+        return {field: getattr(self, field) for field in fields if not field.endswith("id")}
+
     @classmethod
     def _get_select_where_sql(cls, id: str | int) -> Tuple[str, List[str], List[str]]:
         SELECT_WHERE_SQL = "SELECT {fields} FROM {name} WHERE id = ?;"


### PR DESCRIPTION
Add asdcit method to `Table` instances.

Example usage: Assuming you have the models below defined:
```python
class User(Table):
    username = Column(str)
    email = Column(str)

class Post(Table):
    def __repr__(self):
        return f"<Post(title='{self.title}', author='{self.author.username}', id={self.id})>"

    def __str__(self):
        return f"Post: {self.title} by {self.author.username}"

    title = Column(str)
    content = Column(str)
    author = ForeignKey(User)

db.create(User)
db.create(Post)

user = User(username='johndoe', email='john@example.com')
db.save(user)

post = Post(title='Hello World', content='This is my first post.', author=user)
db.save(post)

print(post.asdict)
```

Output
```json
{"content": "This is my first post.", "title": "Hello World"}
```